### PR TITLE
added prometheus filter for high-cardinality tags

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,5 +11,3 @@ require (
 	golang.org/x/net v0.0.0-20190206173232-65e2d4e15006 // indirect
 	golang.org/x/sys v0.0.0-20190204203706-41f3e6584952 // indirect
 )
-
-go 1.12

--- a/go.mod
+++ b/go.mod
@@ -11,5 +11,3 @@ require (
 	golang.org/x/net v0.0.0-20190206173232-65e2d4e15006 // indirect
 	golang.org/x/sys v0.0.0-20190204203706-41f3e6584952 // indirect
 )
-
-go 1.13

--- a/go.mod
+++ b/go.mod
@@ -11,3 +11,5 @@ require (
 	golang.org/x/net v0.0.0-20190206173232-65e2d4e15006 // indirect
 	golang.org/x/sys v0.0.0-20190204203706-41f3e6584952 // indirect
 )
+
+go 1.13

--- a/go.mod
+++ b/go.mod
@@ -12,4 +12,4 @@ require (
 	golang.org/x/sys v0.0.0-20190204203706-41f3e6584952 // indirect
 )
 
-go 1.13
+go 1.12

--- a/prometheus/handler.go
+++ b/prometheus/handler.go
@@ -1,6 +1,7 @@
 package prometheus
 
 import (
+	"bytes"
 	"compress/gzip"
 	"io"
 	"net/http"
@@ -47,6 +48,16 @@ type Handler struct {
 
 	opcount uint64
 	metrics metricStore
+	filters []byte
+}
+
+// FilterLabels will remove the passed labels from the observation
+func (h *Handler) FilterLabels(labelNames []string) {
+	b := make([][]byte, len(labelNames))
+	for i := range labelNames {
+		b[i] = []byte(labelNames[i])
+	}
+	h.filters = bytes.Join(b, []byte{0x00})
 }
 
 // HandleMetric satisfies the stats.Handler interface.
@@ -146,6 +157,7 @@ func (h *Handler) WriteStats(w io.Writer) {
 	sort.Sort(byNameAndLabels(metrics))
 
 	for i, m := range metrics {
+		m.labels = m.labels.filterNamed(h.filters)
 		b = b[:0]
 		name := m.rootName()
 

--- a/prometheus/handler_test.go
+++ b/prometheus/handler_test.go
@@ -119,7 +119,7 @@ C_sum 10.7 1496614320000
 	}
 }
 
-func TestFilterLabels(t *testing.T) {
+func TestIgnoreLabels(t *testing.T) {
 	tests := []struct{
 		name string
 		labels []string
@@ -145,9 +145,9 @@ func TestFilterLabels(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			h := &Handler{}
-			h.FilterLabels(test.labels)
-			if !reflect.DeepEqual(h.filters, test.expect) {
-				t.Errorf("\nexpected: %#v\n     got: %#v", test.expect, h.filters)
+			h.IgnoreLabels(test.labels)
+			if !reflect.DeepEqual(h.ignoredLabels, test.expect) {
+				t.Errorf("\nexpected: %#v\n     got: %#v", test.expect, h.ignoredLabels)
 			}
 		})
 	}

--- a/prometheus/handler_test.go
+++ b/prometheus/handler_test.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"testing"
 	"time"
 
@@ -115,6 +116,40 @@ C_sum 10.7 1496614320000
 		t.Error("bad output:")
 		t.Log("expected:", expects)
 		t.Log("found:", s)
+	}
+}
+
+func TestFilterLabels(t *testing.T) {
+	tests := []struct{
+		name string
+		labels []string
+		expect []byte
+	}{
+		{
+			name: "no labels",
+			labels: []string(nil),
+			expect: make([]byte, 0),
+		},
+		{
+			name: "http_req_path",
+			labels: []string{"http_req_path"},
+			expect: []byte("http_req_path"),
+		},
+		{
+			name: "multiple labels",
+			labels: []string{"l1", "l2", "l3"},
+			expect: []byte{'l', '1', 0x00, 'l', '2', 0x00, 'l', '3'},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			h := &Handler{}
+			h.FilterLabels(test.labels)
+			if !reflect.DeepEqual(h.filters, test.expect) {
+				t.Errorf("\nexpected: %#v\n     got: %#v", test.expect, h.filters)
+			}
+		})
 	}
 }
 

--- a/prometheus/label.go
+++ b/prometheus/label.go
@@ -35,7 +35,7 @@ func makeLabels(l ...label) labels {
 	return m
 }
 
-func (l labels) filterNamed(names []byte) labels {
+func (l labels) ignoreNamed(names []byte) labels {
 	if len(names) == 0 {
 		return l
 	}

--- a/prometheus/label.go
+++ b/prometheus/label.go
@@ -1,6 +1,8 @@
 package prometheus
 
 import (
+	"bytes"
+
 	"github.com/segmentio/fasthash/jody"
 	"github.com/segmentio/stats"
 )
@@ -17,12 +19,12 @@ func (l label) hash() uint64 {
 	return h
 }
 
-func (l1 label) equal(l2 label) bool {
-	return l1.name == l2.name && l1.value == l2.value
+func (l label) equal(l2 label) bool {
+	return l.name == l2.name && l.value == l2.value
 }
 
-func (l1 label) less(l2 label) bool {
-	return l1.name < l2.name || (l1.name == l2.name && l1.value < l2.value)
+func (l label) less(l2 label) bool {
+	return l.name < l2.name || (l.name == l2.name && l.value < l2.value)
 }
 
 type labels []label
@@ -31,6 +33,19 @@ func makeLabels(l ...label) labels {
 	m := make(labels, len(l))
 	copy(m, l)
 	return m
+}
+
+func (l labels) filterNamed(names []byte) labels {
+	if len(names) == 0 {
+		return l
+	}
+	out := make(labels, 0, len(l))
+	for i := range l {
+		if !bytes.Contains(names, []byte(l[i].name)) {
+			out = append(out, l[i])
+		}
+	}
+	return out
 }
 
 func (l labels) copyAppend(m ...label) labels {
@@ -55,25 +70,25 @@ func (l labels) hash() uint64 {
 	return h
 }
 
-func (l1 labels) equal(l2 labels) bool {
-	if len(l1) != len(l2) {
+func (l labels) equal(l2 labels) bool {
+	if len(l) != len(l2) {
 		return false
 	}
-	for i := range l1 {
-		if !l1[i].equal(l2[i]) {
+	for i := range l {
+		if !l[i].equal(l2[i]) {
 			return false
 		}
 	}
 	return true
 }
 
-func (l1 labels) less(l2 labels) bool {
-	n1 := len(l1)
+func (l labels) less(l2 labels) bool {
+	n1 := len(l)
 	n2 := len(l2)
 
 	for i := 0; i != n1 && i != n2; i++ {
-		if !l1[i].equal(l2[i]) {
-			return l1[i].less(l2[i])
+		if !l[i].equal(l2[i]) {
+			return l[i].less(l2[i])
 		}
 	}
 

--- a/prometheus/label_test.go
+++ b/prometheus/label_test.go
@@ -63,7 +63,7 @@ func TestLabelsLess(t *testing.T) {
 	}
 }
 
-func TestFilter(t *testing.T) {
+func TestIgnoreNamed(t *testing.T) {
 	var testFilter = []byte{'l', '1', 0x00, 'l', '2'}
 	var testLabels = labels{
 		{
@@ -92,13 +92,13 @@ func TestFilter(t *testing.T) {
 			expect: make(labels, 0),
 		},
 		{
-			name:   "no filters",
+			name:   "no ignored labels",
 			in:     testLabels,
 			filter: []byte(nil),
 			expect: testLabels,
 		},
 		{
-			name: "active filters",
+			name: "actively ignoring labels",
 			in: testLabels,
 			filter:testFilter,
 			expect: labels{{name: "l3"}, {name: "l4"}},
@@ -107,7 +107,7 @@ func TestFilter(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			l := test.in.filterNamed(test.filter)
+			l := test.in.ignoreNamed(test.filter)
 
 			if !reflect.DeepEqual(l, test.expect) {
 				t.Errorf("\nexpected: %#v\n     got: %#v", test.expect, l)

--- a/prometheus/label_test.go
+++ b/prometheus/label_test.go
@@ -1,6 +1,9 @@
 package prometheus
 
-import "testing"
+import (
+	"reflect"
+	"testing"
+)
 
 func TestLabelsLess(t *testing.T) {
 	tests := []struct {
@@ -55,6 +58,59 @@ func TestLabelsLess(t *testing.T) {
 		t.Run("", func(t *testing.T) {
 			if less := test.l1.less(test.l2); less != test.less {
 				t.Errorf("(%#v < %#v) != %t", test.l1, test.l2, test.less)
+			}
+		})
+	}
+}
+
+func TestFilter(t *testing.T) {
+	var testFilter = []byte{'l', '1', 0x00, 'l', '2'}
+	var testLabels = labels{
+		{
+			name: "l1",
+		},
+		{
+			name: "l2",
+		},
+		{
+			name: "l3",
+		},
+		{
+			name: "l4",
+		},
+	}
+	tests := []struct {
+		name   string
+		in     labels
+		filter []byte
+		expect labels
+	}{
+		{
+			name:   "no labels",
+			in:     labels(nil),
+			filter: testFilter,
+			expect: make(labels, 0),
+		},
+		{
+			name:   "no filters",
+			in:     testLabels,
+			filter: []byte(nil),
+			expect: testLabels,
+		},
+		{
+			name: "active filters",
+			in: testLabels,
+			filter:testFilter,
+			expect: labels{{name: "l3"}, {name: "l4"}},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			l := test.in.filterNamed(test.filter)
+
+			if !reflect.DeepEqual(l, test.expect) {
+				t.Errorf("\nexpected: %#v\n     got: %#v", test.expect, l)
 			}
 		})
 	}


### PR DESCRIPTION
This allows the prometheus handler to filter out high-cardinality labels (e.g. `http_req_path`) from observations

Usage:
```go
// create prometheus handler
handler := &prometheus.Handler{
    TrimPrefix: cfg.StatsDPrefix,
}
// set HC tags
handler.IgnoreLabels([]string{"http_req_path"})
```

Benchmarks:

Before filter (current master):

```
goos: darwin
goarch: amd64
pkg: github.com/segmentio/stats/prometheus
BenchmarkHandleMetric/counter-8                  5687409               189 ns/op               0 B/op          0 allocs/op
BenchmarkHandleMetric/gauge-8                    6038472               187 ns/op               0 B/op          0 allocs/op
BenchmarkHandleMetric/histogram-8                5275975               230 ns/op               0 B/op          0 allocs/op
PASS
ok      github.com/segmentio/stats/prometheus   4.078s

```

After filter (this branch):

```
goos: darwin
goarch: amd64
pkg: github.com/segmentio/stats/prometheus
BenchmarkHandleMetric/counter-8                  6561445               186 ns/op               0 B/op          0 allocs/op
BenchmarkHandleMetric/gauge-8                    6449792               184 ns/op               0 B/op          0 allocs/op
BenchmarkHandleMetric/histogram-8                5353644               223 ns/op               0 B/op          0 allocs/op
PASS
ok      github.com/segmentio/stats/prometheus   4.224s

```